### PR TITLE
Fix blocked event loop

### DIFF
--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -468,18 +468,18 @@ var groupJoinData = function(rows, includeOptions, options) {
       topExists = false;
 
       // Compute top level hash key (this is usually just the primary key values)
-      $length = includeOptions.model.primaryKeyAttributes.length;
+      $length = includeOptions.daoFactory.primaryKeyAttributes.length;
       topHash = '';
       if ($length === 1) {
-        topHash = row[includeOptions.model.primaryKeyAttributes[0]];
+        topHash = row[includeOptions.daoFactory.primaryKeyAttributes[0]];
       }
       else if ($length > 1) {
         for ($i = 0; $i < $length; $i++) {
-          topHash += row[includeOptions.model.primaryKeyAttributes[$i]];
+          topHash += row[includeOptions.daoFactory.primaryKeyAttributes[$i]];
         }
       }
-      else if (!Utils._.isEmpty(includeOptions.model.uniqueKeys)) {
-        uniqueKeyAttributes = getUniqueKeyAttributes(includeOptions.model);
+      else if (!Utils._.isEmpty(includeOptions.daoFactory.uniqueKeys)) {
+        uniqueKeyAttributes = getUniqueKeyAttributes(includeOptions.daoFactory);
         for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
           topHash += row[uniqueKeyAttributes[$i]];
         }
@@ -519,7 +519,7 @@ var groupJoinData = function(rows, includeOptions, options) {
           if (length) {
             for (i = 0; i < length; i++) {
               prefix = $parent ? $parent+'.'+$prevKeyPrefix[i] : $prevKeyPrefix[i];
-              primaryKeyAttributes = includeMap[prefix].model.primaryKeyAttributes;
+              primaryKeyAttributes = includeMap[prefix].daoFactory.primaryKeyAttributes;
               $length = primaryKeyAttributes.length;
               itemHash = prefix;
               if ($length === 1) {
@@ -530,8 +530,8 @@ var groupJoinData = function(rows, includeOptions, options) {
                   itemHash += row[prefix+'.'+primaryKeyAttributes[$i]];
                 }
               }
-              else if (!Utils._.isEmpty(includeMap[prefix].model.uniqueKeys)) {
-                uniqueKeyAttributes = getUniqueKeyAttributes(includeMap[prefix].model);
+              else if (!Utils._.isEmpty(includeMap[prefix].daoFactory.uniqueKeys)) {
+                uniqueKeyAttributes = getUniqueKeyAttributes(includeMap[prefix].daoFactory);
                 for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
                   itemHash += row[prefix+'.'+uniqueKeyAttributes[$i]];
                 }
@@ -606,7 +606,7 @@ var groupJoinData = function(rows, includeOptions, options) {
       if (length) {
         for (i = 0; i < length; i++) {
           prefix = $parent ? $parent+'.'+$prevKeyPrefix[i] : $prevKeyPrefix[i];
-          primaryKeyAttributes = includeMap[prefix].model.primaryKeyAttributes;
+          primaryKeyAttributes = includeMap[prefix].daoFactory.primaryKeyAttributes;
           $length = primaryKeyAttributes.length;
           itemHash = prefix;
           if ($length === 1) {
@@ -617,8 +617,8 @@ var groupJoinData = function(rows, includeOptions, options) {
               itemHash += row[prefix+'.'+primaryKeyAttributes[$i]];
             }
           }
-          else if (!Utils._.isEmpty(includeMap[prefix].model.uniqueKeys)) {
-            uniqueKeyAttributes = getUniqueKeyAttributes(includeMap[prefix].model);
+          else if (!Utils._.isEmpty(includeMap[prefix].daoFactory.uniqueKeys)) {
+            uniqueKeyAttributes = getUniqueKeyAttributes(includeMap[prefix].daoFactory);
             for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
               itemHash += row[prefix+'.'+uniqueKeyAttributes[$i]];
             }

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -298,121 +298,376 @@ module.exports = (function() {
   }
 
 
-  /**
-    The function takes the result of the query execution and groups
-    the associated data by the callee.
-
-    Example:
-      groupJoinData([
-        {
-          some: 'data',
-          id: 1,
-          association: { foo: 'bar', id: 1 }
-        }, {
-          some: 'data',
-          id: 1,
-          association: { foo: 'bar', id: 2 }
-        }, {
-          some: 'data',
-          id: 1,
-          association: { foo: 'bar', id: 3 }
-        }
-      ])
-
-    Result:
-      Something like this:
-
-      [
-        {
-          some: 'data',
-          id: 1,
-          association: [
-            { foo: 'bar', id: 1 },
-            { foo: 'bar', id: 2 },
-            { foo: 'bar', id: 3 }
-          ]
-        }
-      ]
-  */
-
-  // includeOptions are 'level'-specific where options is a general directive
-  var groupJoinData = function(data, includeOptions, options) {
-    var results = []
-      , existingResult
-      , calleeData
-      , child
-      , calleeDataIgnore = ['__children']
-      , parseChildren = function(result) {
-        _.each(result.__children, function (children, key) {
-          result[key] = groupJoinData(children, (includeOptions.includeMap && includeOptions.includeMap[key]), options)
-        })
-        delete result.__children
-      },
-      primaryKeyAttribute
-
-    // Identify singular primaryKey attribute for equality check (if possible)
-    if (includeOptions.daoFactory.primaryKeyAttributes.length === 1) {
-      primaryKeyAttribute = includeOptions.daoFactory.primaryKeyAttributes[0]
-    } else if (includeOptions.daoFactory.rawAttributes.id) {
-      primaryKeyAttribute = 'id'
-    }
-
-    // Ignore all include keys on main data
-    if (includeOptions.includeNames) {
-      calleeDataIgnore = calleeDataIgnore.concat(includeOptions.includeNames)
-    }
-
-    data.forEach(function (row) {
-      row = Dot.transform(row)
-      calleeData = _.omit(row, calleeDataIgnore)
-
-      // If there are :M associations included we need to see if the main result of the row has already been identified
-      existingResult = options.checkExisting && _.find(results, function (result) {
-        // If we can, detect equality on the singular primary key
-        if (primaryKeyAttribute) {
-          return result[primaryKeyAttribute] === calleeData[primaryKeyAttribute]
-        }
-
-        // If we can't identify on a singular primary key, do a full row equality check
-        return Utils._.isEqual(_.omit(result, calleeDataIgnore), calleeData)
-      })
-
-      if (!existingResult) {
-        results.push(existingResult = calleeData)
+/**
+  The function takes the result of the query execution and groups
+  the associated data by the callee.
+  Example:
+    groupJoinData([
+      {
+        some: 'data',
+        id: 1,
+        association: { foo: 'bar', id: 1 }
+      }, {
+        some: 'data',
+        id: 1,
+        association: { foo: 'bar', id: 2 }
+      }, {
+        some: 'data',
+        id: 1,
+        association: { foo: 'bar', id: 3 }
       }
+    ])
+  Result:
+    Something like this:
+    [
+      {
+        some: 'data',
+        id: 1,
+        association: [
+          { foo: 'bar', id: 1 },
+          { foo: 'bar', id: 2 },
+          { foo: 'bar', id: 3 }
+        ]
+      }
+    ]
+*/
+/*
+ * Assumptions
+ * ID is not necessarily the first field
+ * All fields for a level is grouped in the same set (i.e. Panel.id, Task.id, Panel.title is not possible)
+ * Parent keys will be seen before any include/child keys
+ * Previous set won't necessarily be parent set (one parent could have two children, one child would then be previous set for the other)
+ */
 
-      for (var attrName in row) {
-        if (row.hasOwnProperty(attrName)) {
-          // Child if object, and is an child include
-          child = Object(row[attrName]) === row[attrName] && includeOptions.includeMap && includeOptions.includeMap[attrName]
+ /*
+ * Author (MH) comment: This code is an unreadable mess, but its performant.
+ * groupJoinData is a performance critical function so we prioritize perf over readability.
+ */
 
-          if (child) {
-            // Make sure nested object is available
-            if (!existingResult.__children) {
-              existingResult.__children = {}
+var groupJoinData = function(rows, includeOptions, options) {
+  if (!rows.length) {
+    return [];
+  }
+
+  var
+    // Generic looping
+    i
+    , length
+    , $i
+    , $length
+    // Row specific looping
+    , rowsI
+    , rowsLength = rows.length
+    , row
+    // Key specific looping
+    , keys
+    , key
+    , keyI
+    , keyLength
+    , prevKey
+    , values
+    , topValues
+    , topExists
+    , checkExisting = options.checkExisting
+    // If we don't have to deduplicate we can pre-allocate the resulting array
+    , results = checkExisting ? [] : new Array(rowsLength)
+    , resultMap = {}
+    , includeMap = {}
+    , itemHash
+    , parentHash
+    , topHash
+    // Result variables for the respective functions
+    , $keyPrefix
+    , $keyPrefixString
+    , $prevKeyPrefixString
+    , $prevKeyPrefix
+    , $lastKeyPrefix
+    , $current
+    , $parent
+    // Map each key to an include option
+    , previousPiece
+    , buildIncludeMap = function (piece) {
+      if ($current.includeMap[piece]) {
+        includeMap[key] = $current = $current.includeMap[piece];
+        if (previousPiece) {
+          previousPiece = previousPiece+'.'+piece;
+        } else {
+          previousPiece = piece;
+        }
+        includeMap[previousPiece] = $current;
+      }
+    }
+    // Calcuate the last item in the array prefix ('Results' for 'User.Results.id')
+    , lastKeyPrefixMemo = {}
+    , lastKeyPrefix = function (key) {
+      if (!lastKeyPrefixMemo[key]) {
+        var prefix = keyPrefix(key)
+          , length = prefix.length;
+
+        lastKeyPrefixMemo[key] = !length ? '' : prefix[length - 1];
+      }
+      return lastKeyPrefixMemo[key];
+    }
+    // Calculate the string prefix of a key ('User.Results' for 'User.Results.id')
+    , keyPrefixStringMemo = {}
+    , keyPrefixString = function (key, memo) {
+      if (!memo[key]) {
+        memo[key] = key.substr(0, key.lastIndexOf('.'));
+      }
+      return memo[key];
+    }
+    // Removes the prefix from a key ('id' for 'User.Results.id')
+    , removeKeyPrefixMemo = {}
+    , removeKeyPrefix = function (key) {
+      if (!removeKeyPrefixMemo[key]) {
+        var index = key.lastIndexOf('.');
+        removeKeyPrefixMemo[key] = key.substr(index === -1 ? 0 : index + 1);
+      }
+      return removeKeyPrefixMemo[key];
+    }
+    // Calculates the array prefix of a key (['User', 'Results'] for 'User.Results.id')
+    , keyPrefixMemo = {}
+    , keyPrefix = function (key) {
+      // We use a double memo and keyPrefixString so that different keys with the same prefix will receive the same array instead of differnet arrays with equal values
+      if (!keyPrefixMemo[key]) {
+        var prefixString = keyPrefixString(key, keyPrefixStringMemo);
+        if (!keyPrefixMemo[prefixString]) {
+          keyPrefixMemo[prefixString] = prefixString ? prefixString.split('.') : [];
+        }
+        keyPrefixMemo[key] = keyPrefixMemo[prefixString];
+      }
+      return keyPrefixMemo[key];
+    }
+    , getUniqueKeyAttributes = function (model) {
+        var uniqueKeyAttributes = Utils._.chain(model.uniqueKeys);
+        uniqueKeyAttributes = uniqueKeyAttributes
+        .result(uniqueKeyAttributes.findKey() + '.fields')
+        .map(function(field){
+          return Utils._.findKey(model.attributes, function(chr) {
+            return chr.field === field;
+          });
+        })
+        .value();
+
+        return uniqueKeyAttributes;
+    }
+    , primaryKeyAttributes
+    , uniqueKeyAttributes
+    , prefix;
+
+  for (rowsI = 0; rowsI < rowsLength; rowsI++) {
+    row = rows[rowsI];
+
+    // Keys are the same for all rows, so only need to compute them on the first row
+    if (rowsI === 0) {
+      keys = Object.keys(row);
+      keyLength = keys.length;
+    }
+
+    if (checkExisting) {
+      topExists = false;
+
+      // Compute top level hash key (this is usually just the primary key values)
+      $length = includeOptions.model.primaryKeyAttributes.length;
+      topHash = '';
+      if ($length === 1) {
+        topHash = row[includeOptions.model.primaryKeyAttributes[0]];
+      }
+      else if ($length > 1) {
+        for ($i = 0; $i < $length; $i++) {
+          topHash += row[includeOptions.model.primaryKeyAttributes[$i]];
+        }
+      }
+      else if (!Utils._.isEmpty(includeOptions.model.uniqueKeys)) {
+        uniqueKeyAttributes = getUniqueKeyAttributes(includeOptions.model);
+        for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
+          topHash += row[uniqueKeyAttributes[$i]];
+        }
+      }
+    }
+
+    topValues = values = {};
+    $prevKeyPrefix = undefined;
+    for (keyI = 0; keyI < keyLength; keyI++) {
+      key = keys[keyI];
+
+      // The string prefix isn't actualy needed
+      // We use it so keyPrefix for different keys will resolve to the same array if they have the same prefix
+      // TODO: Find a better way?
+      $keyPrefixString = keyPrefixString(key, keyPrefixStringMemo);
+      $keyPrefix = keyPrefix(key);
+
+      // On the first row we compute the includeMap
+      if (rowsI === 0 && includeMap[key] === undefined) {
+        if (!$keyPrefix.length) {
+          includeMap[key] = includeMap[''] = includeOptions;
+        } else {
+          $current = includeOptions;
+          previousPiece = undefined;
+          $keyPrefix.forEach(buildIncludeMap);
+        }
+      }
+      // End of key set
+      if ($prevKeyPrefix !== undefined && $prevKeyPrefix !== $keyPrefix) {
+        if (checkExisting) {
+          // Compute hash key for this set instance
+          // TODO: Optimize
+          length = $prevKeyPrefix.length;
+          $parent = null;
+          parentHash = null;
+
+          if (length) {
+            for (i = 0; i < length; i++) {
+              prefix = $parent ? $parent+'.'+$prevKeyPrefix[i] : $prevKeyPrefix[i];
+              primaryKeyAttributes = includeMap[prefix].model.primaryKeyAttributes;
+              $length = primaryKeyAttributes.length;
+              itemHash = prefix;
+              if ($length === 1) {
+                itemHash += row[prefix+'.'+primaryKeyAttributes[0]];
+              }
+              else if ($length > 1) {
+                for ($i = 0; $i < $length; $i++) {
+                  itemHash += row[prefix+'.'+primaryKeyAttributes[$i]];
+                }
+              }
+              else if (!Utils._.isEmpty(includeMap[prefix].model.uniqueKeys)) {
+                uniqueKeyAttributes = getUniqueKeyAttributes(includeMap[prefix].model);
+                for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
+                  itemHash += row[prefix+'.'+uniqueKeyAttributes[$i]];
+                }
+              }
+              if (!parentHash) {
+                parentHash = topHash;
+              }
+
+              itemHash = parentHash + itemHash;
+              $parent = prefix;
+              if (i < length - 1) {
+                parentHash = itemHash;
+              }
             }
-            if (!existingResult.__children[attrName]) {
-              existingResult.__children[attrName] = []
-            }
+          } else {
+            itemHash = topHash;
+          }
 
-            existingResult.__children[attrName].push(row[attrName])
+          if (itemHash === topHash) {
+            if (!resultMap[itemHash]) {
+              resultMap[itemHash] = values;
+            } else {
+              topExists = true;
+            }
+          } else {
+            if (!resultMap[itemHash]) {
+              $parent = resultMap[parentHash];
+              $lastKeyPrefix = lastKeyPrefix(prevKey);
+
+              if (includeMap[prevKey].association.isSingleAssociation) {
+                $parent[$lastKeyPrefix] = resultMap[itemHash] = values;
+              } else {
+                if (!$parent[$lastKeyPrefix]) {
+                  $parent[$lastKeyPrefix] = [];
+                }
+                $parent[$lastKeyPrefix].push(resultMap[itemHash] = values);
+              }
+            }
+          }
+
+          // Reset values
+          values = {};
+        } else {
+          // If checkExisting is false it's because there's only 1:1 associations in this query
+          // However we still need to map onto the appropriate parent
+          // For 1:1 we map forward, initializing the value object on the parent to be filled in the next iterations of the loop
+          $current = topValues;
+          length = $keyPrefix.length;
+          if (length) {
+            for (i = 0; i < length; i++) {
+              if (i === length -1) {
+                values = $current[$keyPrefix[i]] = {};
+              }
+              $current = $current[$keyPrefix[i]];
+            }
           }
         }
       }
 
-      // parseChildren in same loop if no duplicate values are possible
-      if (!options.checkExisting) {
-        parseChildren(existingResult)
-      }
-    })
-    
-    // parseChildren after row parsing if duplicate values are possible
-    if (options.checkExisting) {
-      results.forEach(parseChildren)
+      // End of iteration, set value and set prev values (for next iteration)
+      values[removeKeyPrefix(key)] = row[key];
+      prevKey = key;
+      $prevKeyPrefix = $keyPrefix;
+      $prevKeyPrefixString = $keyPrefixString;
     }
 
-    return results
+    if (checkExisting) {
+      length = $prevKeyPrefix.length;
+      $parent = null;
+      parentHash = null;
+
+      if (length) {
+        for (i = 0; i < length; i++) {
+          prefix = $parent ? $parent+'.'+$prevKeyPrefix[i] : $prevKeyPrefix[i];
+          primaryKeyAttributes = includeMap[prefix].model.primaryKeyAttributes;
+          $length = primaryKeyAttributes.length;
+          itemHash = prefix;
+          if ($length === 1) {
+            itemHash += row[prefix+'.'+primaryKeyAttributes[0]];
+          }
+          else if ($length > 0) {
+            for ($i = 0; $i < $length; $i++) {
+              itemHash += row[prefix+'.'+primaryKeyAttributes[$i]];
+            }
+          }
+          else if (!Utils._.isEmpty(includeMap[prefix].model.uniqueKeys)) {
+            uniqueKeyAttributes = getUniqueKeyAttributes(includeMap[prefix].model);
+            for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
+              itemHash += row[prefix+'.'+uniqueKeyAttributes[$i]];
+            }
+          }
+          if (!parentHash) {
+            parentHash = topHash;
+          }
+
+          itemHash = parentHash + itemHash;
+          $parent = prefix;
+          if (i < length - 1) {
+            parentHash = itemHash;
+          }
+        }
+      } else {
+        itemHash = topHash;
+      }
+
+      if (itemHash === topHash) {
+        if (!resultMap[itemHash]) {
+          resultMap[itemHash] = values;
+        } else {
+          topExists = true;
+        }
+      } else {
+        if (!resultMap[itemHash]) {
+          $parent = resultMap[parentHash];
+          $lastKeyPrefix = lastKeyPrefix(prevKey);
+
+          if (includeMap[prevKey].association.isSingleAssociation) {
+            $parent[$lastKeyPrefix] = resultMap[itemHash] = values;
+          } else {
+            if (!$parent[$lastKeyPrefix]) {
+              $parent[$lastKeyPrefix] = [];
+            }
+            $parent[$lastKeyPrefix].push(resultMap[itemHash] = values);
+          }
+        }
+      }
+      if (!topExists) {
+        results.push(topValues);
+      }
+    } else {
+      results[rowsI] = topValues;
+    }
   }
+
+  return results;
+};
 
   return AbstractQuery
 })()


### PR DESCRIPTION
Fix event loop blocking behavior in Sequelize.  All this time we thought the event loop was being blocked by the MySQL driver, but it was actually this groupJoinData() method in Sequelize!  I back-ported enhancements to this method from the latest Sequelize release.

I used this burly query as a test: `/yoshimi/merchants?filter=id:eq:1&include=locations,deals,customers&attributes=id,locations:id,deals:id,customers:id&customers_with=id:gte:842001`.  Run against the integration DB it returns a SQL resultset with 855400 rows.  Before this fix the groupJoinData() method blocked the event loop for 46s.  After this fix it only blocks it for 5s!
