### PR TITLE
[INFRA-101] Fix bug in creating connection pool

### DIFF
--- a/lib/dialects/mysql/connector-manager.js
+++ b/lib/dialects/mysql/connector-manager.js
@@ -128,10 +128,14 @@ module.exports = (function() {
       this.pool = Pooling.Pool({
         name: 'sequelize-mysql',
         create: function (done) {
-          connect.call(self, function (err, connection) {
-            // This has to be nested for some reason, else the error won't propagate correctly
-            done(err, connection);
-          })
+          // Wait a tick, since in some paths it references this.pool, which we're in the process
+          // of defining!
+          setImmediate(function() {
+            connect.call(self, function (err, connection) {
+              // This has to be nested for some reason, else the error won't propagate correctly
+              done(err, connection);
+            });
+          });
         },
         destroy: function(client) {
           disconnect.call(self, client)
@@ -153,7 +157,7 @@ module.exports = (function() {
 
       return
     }.bind(this);
-    
+
     process.on('exit', this.onProcessExit)
   }
 
@@ -185,7 +189,7 @@ module.exports = (function() {
           setTimeout(function() {
             if (self.pendingQueries === 0){
               self.disconnect.call(self);
-            } 
+            }
           }, 100);
         }
       }


### PR DESCRIPTION
This allows the handleDisconnect option to work as intended.

Without this fix, the following was happening in the same tick:
- Pooling.Pool calls the provided 'create' method
- The 'create' method calls 'connect', passing in 'this' as 'self'
- If handleDisconnects is true, 'connect' calls 'handleDisconnect' with this.pool (currently undefined), which sets up a listener that attempts to call a method on it (this is the bug)
- Pooling.Pool finishes and the result is assigned to this.pool

Having the call to 'connect' occur on the next tick ensures this.pool is bound before it's used.

There's probably a similar bug in the block above this PR, but that's only if the "replication" option is used, which we're not using, and I didn't see the need to fix something we're not using.