### PR TITLE
Allow overriding the data type of the default 'id' primary key

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -14,6 +14,7 @@ module.exports = (function() {
       createdAt: 'createdAt',
       updatedAt: 'updatedAt',
       deletedAt: 'deletedAt',
+      defaultPrimaryKeyDataType: DataTypes.INTEGER,
       instanceMethods: {},
       classMethods: {},
       validate: {},
@@ -1302,7 +1303,7 @@ module.exports = (function() {
       , tail = {}
       , head = {
         id: {
-          type: DataTypes.INTEGER,
+          type: this.options.defaultPrimaryKeyDataType,
           allowNull: false,
           primaryKey: true,
           autoIncrement: true,


### PR DESCRIPTION
This will be useful for tables that want a BIGINT primary key instead of just INT.

I've tested locally this we'll be able to use this in Core's model files.